### PR TITLE
Add AES Hardware Abstraction for MAX78000 HAL

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+target = "thumbv7em-none-eabihf"

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ target/
 
 # MSVC Windows builds of rustc generate these, which store debugging information
 *.pdb
+
+.idea

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46afbd2983a5d5a7bd740ccb198caf5b82f45c40c09c0eed36052d91cb92e719"
 
 [[package]]
+name = "cipher"
+version = "0.5.0-pre.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b1425e6ce000f05a73096556cabcfb6a10a3ffe3bb4d75416ca8f00819c0b6a"
+dependencies = [
+ "crypto-common",
+ "inout",
+]
+
+[[package]]
 name = "cortex-m"
 version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -56,6 +66,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
+name = "crypto-common"
+version = "0.2.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0b8ce8218c97789f16356e7896b3714f26c2ee1079b79c0b7ae7064bb9089fa"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "embedded-hal"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -88,6 +107,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
+name = "hybrid-array"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2d35805454dc9f8662a98d6d61886ffe26bd465f5960e0e55345c70d5c0d2a9"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
+name = "inout"
+version = "0.2.0-rc.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de49db00f5add6dad75a57946b75de0f26287a6fc95f4f277d48419200422beb"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "max78000-pac"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -103,6 +140,7 @@ dependencies = [
 name = "max7800x-hal"
 version = "0.4.0"
 dependencies = [
+ "cipher",
  "cortex-m",
  "cortex-m-rt",
  "embedded-hal 1.0.0",
@@ -202,6 +240,12 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
+
+[[package]]
+name = "typenum"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "unicode-ident"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ max78000-pac = "0.3.0"
 paste = "1.0.15"
 rand = { version = "0.8.5", default-features = false, optional = true }
 rand_core = { version = "0.6.4", default-features = false, optional = true }
+cipher = "0.5.0-pre.7"
 
 [features]
 default = ["rand", "rt"]

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ If you want updates for when new releases are made, you can watch this repositor
 ## Getting Started
 If you already have an existing Rust project, you can add this crate by running:
 ```sh
-cargo add --features "rt" max7800x-hal
+cargo add max7800x-hal
 ```
 
 Otherwise, we recommend getting started using this [Crate template for the MAX78000FTHR board](https://github.com/sigpwny/max78000fthr-template). If you are not using the MAX78000FTHR board, you can still use the template as a reference for setting up your own project.

--- a/src/aes.rs
+++ b/src/aes.rs
@@ -1,0 +1,195 @@
+use max78000_pac::aes::ctrl::KeySize;
+use crate::gcr::ResetForPeripheral;
+
+pub const AES_KEYS: usize = 0x4000_7800;
+
+#[repr(u8)]
+pub enum CipherType {
+    Encrypt = 0b_00,
+    Decrypt = 0b_01,
+}
+
+pub enum Key<'a> {
+    Bits128(&'a [u8; 16]),
+    Bits192(&'a [u8; 24]),
+    Bits256(&'a [u8; 32]),
+}
+
+impl<'a> Key<'a> {
+    fn size(&self) -> usize {
+        match self {
+            Key::Bits128(_) => { 16 }
+            Key::Bits192(_) => { 24 }
+            Key::Bits256(_) => { 32 }
+        }
+    }
+
+    fn as_ptr(&self) -> *const u8 {
+        match self {
+            Key::Bits128(key) => { key.as_ptr() }
+            Key::Bits192(key) => { key.as_ptr() }
+            Key::Bits256(key) => { key.as_ptr() }
+        }
+    }
+}
+
+impl Into<KeySize> for &Key<'_> {
+    fn into(self) -> KeySize {
+        match self {
+            Key::Bits128(_) => {KeySize::Aes128}
+            Key::Bits192(_) => {KeySize::Aes192}
+            Key::Bits256(_) => {KeySize::Aes256}
+        }
+    }
+}
+
+pub struct AES {
+    aes: crate::pac::Aes
+}
+
+
+impl AES {
+    pub fn new(aes: crate::pac::Aes, reg: &mut crate::gcr::GcrRegisters) -> AES {
+        use crate::gcr::ClockForPeripheral;
+        unsafe {
+            aes.reset(&mut reg.gcr);
+            aes.enable_clock(&mut reg.gcr);
+        }
+
+        aes.inten().write(|reg| reg.done().clear_bit());
+
+        Self { aes }
+    }
+
+    fn _is_busy(&self) -> bool {
+        self.aes.status().read().busy().bit_is_set()
+    }
+
+    pub fn set_key(&mut self, key: &Key) {
+
+        /// Wait for AES module to not be busy
+        while self._is_busy() {}
+
+        /// Disable aes module for key change
+        self.aes.ctrl().write(|reg| reg.en().clear_bit());
+
+        /// Check if fifos are empty and if they are not flush the current fifos
+        if self.aes.status().read().input_em().bit_is_clear() {
+            self.aes.ctrl().write(|reg| reg.input_flush().set_bit());
+        }
+        if self.aes.status().read().output_em().bit_is_clear() {
+            self.aes.ctrl().write(|reg| reg.output_flush().set_bit());
+        }
+
+        /// Configure Key size
+        self.aes.ctrl().write(|reg| reg.key_size().variant(key.into()));
+
+
+        unsafe {
+            for i in 0..256 {
+                core::ptr::write_volatile((AES_KEYS + (i * 4)) as *mut u32, 0u32);
+            }
+            core::ptr::copy_nonoverlapping(key.as_ptr(), AES_KEYS as *mut u8, key.size())
+        }
+
+        self.aes.ctrl().write(|reg| reg.en().set_bit());
+
+        // self.add_data_to_fifo(&[0u8; 16]);
+
+    }
+
+    pub fn set_cipher_type(&mut self, cipher_type: CipherType) {
+        self.aes.ctrl().write(|reg| {reg.en().clear_bit()});
+        self.aes.ctrl().write(|reg| unsafe {reg.type_().bits(cipher_type as u8)});
+        self.aes.ctrl().write(|reg| {reg.en().set_bit()});
+
+    }
+
+    // Helper function to process a 16-byte block
+    fn add_block_to_fifo(&mut self, block: &[u8; 16]) {
+        let words = [
+            u32::from_be_bytes(block[12..16].try_into().unwrap()),
+            u32::from_be_bytes(block[8..12].try_into().unwrap()),
+            u32::from_be_bytes(block[4..8].try_into().unwrap()),
+            u32::from_be_bytes(block[0..4].try_into().unwrap()),
+
+        ];
+
+        for &word in &words {
+            self.aes.fifo().write(|reg| unsafe { reg.bits(word) });
+        }
+    }
+
+    // Main function to add data to the FIFO
+    pub fn add_data_to_fifo(&mut self, data: &[u8]) {
+        // Wait until FIFO is ready
+        while self._is_busy() {}
+
+
+        // Process full 16-byte chunks
+        for chunk in data.chunks_exact(16) {
+            self.add_block_to_fifo(chunk.try_into().unwrap());
+        }
+
+        // Handle the remainder (less than 16 bytes)
+        let remainder = data.chunks_exact(16).remainder();
+        if !remainder.is_empty() {
+            let mut padded_block = [0u8; 16];
+            padded_block[..remainder.len()].copy_from_slice(remainder);
+
+            // Apply PKCS#7 padding
+            let padding_size = 16 - remainder.len();
+            padded_block[remainder.len()..].fill(padding_size as u8);
+
+            self.add_block_to_fifo(&padded_block);
+        }
+    }
+
+    fn fetch_block_from_fifo(&mut self) -> [u8; 16] {
+        while self._is_busy() {}
+
+        let mut data = [0u8; 16];
+        for chunk in data.chunks_exact_mut(4).rev() {
+            let word = self.aes.fifo().read().bits();
+            let bytes = word.to_be_bytes(); // Convert the 32-bit word to 4 bytes
+            chunk.copy_from_slice(&bytes);
+        }
+        data
+    }
+
+    // Main function to fetch data of variable size
+    pub fn fetch_data_from_fifo(&mut self, output: &mut [u8]) {
+        while self._is_busy() {}
+
+
+        // Fetch full blocks
+        for chunk in output.chunks_exact_mut(16) {
+            let block = self.fetch_block_from_fifo();
+            chunk.copy_from_slice(&block);
+        }
+
+        // Handle remainder
+        let remainder = output.chunks_exact_mut(16).into_remainder();
+        if !remainder.is_empty() {
+            let block = self.fetch_block_from_fifo();
+            remainder.copy_from_slice(&block[..remainder.len()]);
+        }
+
+    }
+}
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/src/aes.rs
+++ b/src/aes.rs
@@ -1,80 +1,91 @@
 use max78000_pac::aes::ctrl::KeySize;
 use crate::gcr::ResetForPeripheral;
 
+/// Address of the AES key registers in memory.
 pub const AES_KEYS: usize = 0x4000_7800;
 
+/// Enum representing the type of cipher operation.
 #[repr(u8)]
 #[derive(Clone, Copy)]
 pub enum CipherType {
-    Encrypt = 0b_00,
-    Decrypt = 0b_10,
+    Encrypt = 0b_00, // Encryption mode
+    Decrypt = 0b_10, // Decryption mode
 }
 
+/// Enum for representing the AES key sizes.
 pub enum Key<'a> {
-    Bits128(&'a [u8; 16]),
-    Bits192(&'a [u8; 24]),
-    Bits256(&'a [u8; 32]),
+    Bits128(&'a [u8; 16]), // 128-bit key
+    Bits192(&'a [u8; 24]), // 192-bit key
+    Bits256(&'a [u8; 32]), // 256-bit key
 }
 
 impl<'a> Key<'a> {
+    /// Returns the size of the key in bytes.
     fn size(&self) -> usize {
         match self {
-            Key::Bits128(_) => { 16 }
-            Key::Bits192(_) => { 24 }
-            Key::Bits256(_) => { 32 }
+            Key::Bits128(_) => 16,
+            Key::Bits192(_) => 24,
+            Key::Bits256(_) => 32,
         }
     }
 
+    /// Returns a pointer to the key data.
     fn as_ptr(&self) -> *const u8 {
         match self {
-            Key::Bits128(key) => { key.as_ptr() }
-            Key::Bits192(key) => { key.as_ptr() }
-            Key::Bits256(key) => { key.as_ptr() }
+            Key::Bits128(key) => key.as_ptr(),
+            Key::Bits192(key) => key.as_ptr(),
+            Key::Bits256(key) => key.as_ptr(),
         }
     }
 }
 
 impl Into<KeySize> for &Key<'_> {
+    /// Converts a `Key` into the corresponding `KeySize` enum variant.
     fn into(self) -> KeySize {
         match self {
-            Key::Bits128(_) => {KeySize::Aes128}
-            Key::Bits192(_) => {KeySize::Aes192}
-            Key::Bits256(_) => {KeySize::Aes256}
+            Key::Bits128(_) => KeySize::Aes128,
+            Key::Bits192(_) => KeySize::Aes192,
+            Key::Bits256(_) => KeySize::Aes256,
         }
     }
 }
 
+/// AES struct for handling encryption and decryption using the AES hardware module.
 pub struct AES {
-    aes: crate::pac::Aes
+    aes: crate::pac::Aes,
 }
 
-
 impl AES {
+    /// Creates a new AES instance and initializes the hardware module.
     pub fn new(aes: crate::pac::Aes, reg: &mut crate::gcr::GcrRegisters) -> AES {
         use crate::gcr::ClockForPeripheral;
+
+        // Reset and enable the AES hardware module.
         unsafe {
             aes.reset(&mut reg.gcr);
             aes.enable_clock(&mut reg.gcr);
         }
 
+        // Disable AES interrupt notifications.
         aes.inten().write(|reg| reg.done().clear_bit());
 
         Self { aes }
     }
 
+    /// Checks if the AES hardware module is currently busy.
     fn _is_busy(&self) -> bool {
         self.aes.status().read().busy().bit_is_set()
     }
 
+    /// Configures the AES hardware with the provided key.
     pub fn set_key(&mut self, key: &Key) {
-
-        /// Wait for AES module to not be busy
+        // Wait until the AES module is not busy.
         while self._is_busy() {}
 
-        /// Disable aes module for key change
+        // Disable the AES module to configure the key.
         self.aes.ctrl().write(|reg| reg.en().clear_bit());
 
-        /// Check if fifos are empty and if they are not flush the current fifos
+        // Flush input and output FIFOs if not empty.
         if self.aes.status().read().input_em().bit_is_clear() {
             self.aes.ctrl().write(|reg| reg.input_flush().set_bit());
         }
@@ -82,43 +93,47 @@ impl AES {
             self.aes.ctrl().write(|reg| reg.output_flush().set_bit());
         }
 
-        /// Configure Key size
+        // Configure the key size.
         self.aes.ctrl().write(|reg| reg.key_size().variant(key.into()));
 
-
+        // Write the key into the AES key registers.
         unsafe {
             for i in 0..256 {
                 core::ptr::write_volatile((AES_KEYS + (i * 4)) as *mut u32, 0u32);
             }
-            core::ptr::copy_nonoverlapping(key.as_ptr(), AES_KEYS as *mut u8, key.size())
+            core::ptr::copy_nonoverlapping(key.as_ptr(), AES_KEYS as *mut u8, key.size());
         }
 
+        // Enable the AES module.
         self.aes.ctrl().write(|reg| reg.en().set_bit());
-
-        // self.add_data_to_fifo(&[0u8; 16]);
-
     }
 
+    /// Configures the AES hardware for encryption or decryption.
     pub fn set_cipher_type(&mut self, cipher_type: CipherType) {
+        // Wait until the AES module is not busy.
         while self._is_busy() {}
+
+        // Disable the AES module to change the mode.
         self.aes.ctrl().write(|reg| reg.en().clear_bit());
 
+        // Configure the cipher type (encrypt or decrypt).
         self.aes.ctrl().modify(|read, write| unsafe {
             let mut data = read.bits();
             data |= (cipher_type as u32) << 8 | 1;
             write.bits(data)
         });
-
     }
 
-    // Helper function to process a 16-byte block
+    /// Helper function to write a single 16-byte block to the input FIFO.
+    ///
+    /// # Warning:
+    /// This function assumes the block size is exactly 16 bytes.
     fn write_block_to_fifo(&mut self, block: &[u8; 16]) {
         let words = [
             u32::from_be_bytes(block[12..16].try_into().unwrap()),
             u32::from_be_bytes(block[8..12].try_into().unwrap()),
             u32::from_be_bytes(block[4..8].try_into().unwrap()),
             u32::from_be_bytes(block[0..4].try_into().unwrap()),
-
         ];
 
         for &word in &words {
@@ -126,31 +141,23 @@ impl AES {
         }
     }
 
-    // Main function to add data to the FIFO
+    /// Writes data to the AES hardware input FIFO in 16-byte chunks.
+    ///
+    /// # Warning:
+    /// Any remainder bytes (less than 16) at the end of the input will be ignored.
     pub fn write_data_to_fifo(&mut self, data: &[u8]) {
-        // Wait until FIFO is ready
+        // Wait until the FIFO is ready.
         while self._is_busy() {}
 
-
-        // Process full 16-byte chunks
+        // Process full 16-byte chunks.
         for chunk in data.chunks_exact(16) {
             self.write_block_to_fifo(chunk.try_into().unwrap());
         }
 
-        // Handle the remainder (less than 16 bytes)
-        let remainder = data.chunks_exact(16).remainder();
-        if !remainder.is_empty() {
-            let mut padded_block = [0u8; 16];
-            padded_block[..remainder.len()].copy_from_slice(remainder);
-
-            // Apply PKCS#7 padding
-            let padding_size = 16 - remainder.len();
-            padded_block[remainder.len()..].fill(padding_size as u8);
-
-            self.write_block_to_fifo(&padded_block);
-        }
+        // Warning: Any data not divisible by 16 bytes is ignored here.
     }
 
+    /// Reads a single 16-byte block from the output FIFO.
     fn read_block_from_fifo(&mut self) -> [u8; 16] {
         while self._is_busy() {}
 
@@ -163,39 +170,19 @@ impl AES {
         data
     }
 
-    // Main function to fetch data of variable size
+    /// Reads multiple 16-byte blocks from the AES output FIFO into the provided buffer.
+    ///
+    /// # Warning:
+    /// This function assumes the output buffer is a multiple of 16 bytes.
     pub fn read_data_from_fifo(&mut self, output: &mut [u8]) {
         while self._is_busy() {}
 
-
-        // Fetch full blocks
+        // Process full 16-byte chunks.
         for chunk in output.chunks_exact_mut(16) {
             let block = self.read_block_from_fifo();
             chunk.copy_from_slice(&block);
         }
 
-        // Handle remainder
-        let remainder = output.chunks_exact_mut(16).into_remainder();
-        if !remainder.is_empty() {
-            let block = self.read_block_from_fifo();
-            remainder.copy_from_slice(&block[..remainder.len()]);
-        }
-
+        // Warning: If the output buffer size is not a multiple of 16 bytes, the extra space will remain unchanged.
     }
 }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/src/gcr/clocks.rs
+++ b/src/gcr/clocks.rs
@@ -150,7 +150,10 @@ pub struct Clock<SRC: ClockOption> {
     _src: PhantomData<SRC>,
     pub frequency: u32,
 }
-impl<SRC> Clone for Clock<SRC> where SRC: ClockOption {
+impl<SRC> Clone for Clock<SRC>
+where
+    SRC: ClockOption,
+{
     fn clone(&self) -> Self {
         *self
     }

--- a/src/gcr/clocks.rs
+++ b/src/gcr/clocks.rs
@@ -2,7 +2,7 @@
 //!
 //! This module provides a full [typestate](https://docs.rust-embedded.org/book/static-guarantees/typestate-programming.html)
 //! API for enabling oscillators, configuring the system clock, and calculating
-//! clock frequencies. By using typestates, calculation of clock frequencies 
+//! clock frequencies. By using typestates, calculation of clock frequencies
 //! are done entirely at compile time, with no runtime or memory overhead.
 
 use core::marker::PhantomData;
@@ -137,7 +137,6 @@ impl SystemClockDivider for Div128 {
     const DIVISOR: u32 = 128;
 }
 
-
 /// Oscillators represent the state of a physical oscillator. To use an
 /// oscillator, it must be enabled. Then, it can be converted into a clock.
 pub struct Oscillator<O: OscillatorSource, S: OscillatorState> {
@@ -157,7 +156,10 @@ pub struct OscillatorGuard<O: OscillatorSource> {
     _source: PhantomData<O>,
 }
 
-impl<O> OscillatorGuard<O> where O: OscillatorSource {
+impl<O> OscillatorGuard<O>
+where
+    O: OscillatorSource,
+{
     pub(super) fn new() -> Self {
         Self {
             _source: PhantomData,
@@ -186,7 +188,10 @@ impl OscillatorGuards {
 
 /// Initialization of an [`Oscillator`] requires consumption of a
 /// corresponding typed OscillatorGuard.
-impl<O> Oscillator<O, Disabled> where O: OscillatorSource {
+impl<O> Oscillator<O, Disabled>
+where
+    O: OscillatorSource,
+{
     pub fn new(_guard: OscillatorGuard<O>) -> Self {
         Self {
             _source: PhantomData,
@@ -197,9 +202,10 @@ impl<O> Oscillator<O, Disabled> where O: OscillatorSource {
 
 pub type Ipo = Oscillator<InternalPrimaryOscillator, Disabled>;
 impl Ipo {
-    pub fn enable(&self, reg: &mut super::GcrRegisters) ->
-    Oscillator<InternalPrimaryOscillator, Enabled>
-    {
+    pub fn enable(
+        &self,
+        reg: &mut super::GcrRegisters,
+    ) -> Oscillator<InternalPrimaryOscillator, Enabled> {
         reg.gcr.clkctrl().modify(|_, w| w.ipo_en().set_bit());
         while reg.gcr.clkctrl().read().ipo_rdy().bit_is_clear() {}
         Oscillator {
@@ -209,9 +215,7 @@ impl Ipo {
     }
 }
 impl Oscillator<InternalPrimaryOscillator, Enabled> {
-    pub const fn into_clock(self) ->
-    Clock<InternalPrimaryOscillator>
-    {
+    pub const fn into_clock(self) -> Clock<InternalPrimaryOscillator> {
         Clock::<InternalPrimaryOscillator> {
             _src: PhantomData,
             frequency: InternalPrimaryOscillator::BASE_FREQUENCY,
@@ -221,9 +225,10 @@ impl Oscillator<InternalPrimaryOscillator, Enabled> {
 
 pub type Iso = Oscillator<InternalSecondaryOscillator, Disabled>;
 impl Iso {
-    pub fn enable(self, reg: &mut super::GcrRegisters) ->
-    Oscillator<InternalSecondaryOscillator, Enabled>
-    {
+    pub fn enable(
+        self,
+        reg: &mut super::GcrRegisters,
+    ) -> Oscillator<InternalSecondaryOscillator, Enabled> {
         reg.gcr.clkctrl().modify(|_, w| w.iso_en().set_bit());
         while reg.gcr.clkctrl().read().iso_rdy().bit_is_clear() {}
         Oscillator {
@@ -255,9 +260,10 @@ impl Oscillator<InternalSecondaryOscillator, Enabled> {
 
 pub type Ibro = Oscillator<InternalBaudRateOscillator, Disabled>;
 impl Ibro {
-    pub fn enable(self, reg: &mut super::GcrRegisters) ->
-    Oscillator<InternalBaudRateOscillator, Enabled>
-    {
+    pub fn enable(
+        self,
+        reg: &mut super::GcrRegisters,
+    ) -> Oscillator<InternalBaudRateOscillator, Enabled> {
         // IBRO is always enabled
         while reg.gcr.clkctrl().read().ibro_rdy().bit_is_clear() {}
         Oscillator {
@@ -277,9 +283,10 @@ impl Oscillator<InternalBaudRateOscillator, Enabled> {
 
 pub type Ertco = Oscillator<ExternalRtcOscillator, Disabled>;
 impl Oscillator<ExternalRtcOscillator, Disabled> {
-    pub fn enable(self, reg: &mut super::GcrRegisters) ->
-    Oscillator<ExternalRtcOscillator, Enabled>
-    {
+    pub fn enable(
+        self,
+        reg: &mut super::GcrRegisters,
+    ) -> Oscillator<ExternalRtcOscillator, Enabled> {
         reg.gcr.clkctrl().modify(|_, w| w.ertco_en().set_bit());
         while reg.gcr.clkctrl().read().ertco_rdy().bit_is_clear() {}
         todo!("ERTCO requires initialization of the RTC peripheral");
@@ -291,10 +298,7 @@ impl Oscillator<ExternalRtcOscillator, Disabled> {
 }
 
 /// System clock setup configuration (source and divider).
-pub struct SystemClockConfig<
-    S: OscillatorSource,
-    D: SystemClockDivider,
-> {
+pub struct SystemClockConfig<S: OscillatorSource, D: SystemClockDivider> {
     _source: PhantomData<S>,
     _divider: PhantomData<D>,
 }

--- a/src/gcr/mod.rs
+++ b/src/gcr/mod.rs
@@ -17,10 +17,7 @@ pub struct GcrRegisters {
 pub struct Gcr {
     pub reg: GcrRegisters,
     pub osc_guards: clocks::OscillatorGuards,
-    pub sys_clk: clocks::SystemClockConfig<
-        clocks::InternalSecondaryOscillator,
-        clocks::DivUnknown
-    >,
+    pub sys_clk: clocks::SystemClockConfig<clocks::InternalSecondaryOscillator, clocks::DivUnknown>,
 }
 
 impl Gcr {
@@ -101,7 +98,6 @@ macro_rules! generate_reset {
     };
 }
 
-
 generate_clock!(Adc, Gcr, pclkdis0, adc);
 generate_clock!(Aes, Gcr, pclkdis1, aes);
 // CNN?
@@ -142,10 +138,10 @@ generate_reset!(Aes, Gcr, rst1, aes);
 // CPU1 (RISC-V core)?
 generate_reset!(Crc, Gcr, rst1, crc);
 generate_reset!(Dma, Gcr, rst0, dma);
-generate_reset!(Dvs, Gcr, rst1, dvs);       // Note: Dynamic Voltage Scaling Controller does not have its own peripheral clock
-generate_reset!(Gpio0, Gcr, rst0, gpio0);   // Note: Peripheral resets may not affect the GPIO peripherals
-generate_reset!(Gpio1, Gcr, rst0, gpio1);   // Note: Peripheral resets may not affect the GPIO peripherals
-generate_reset!(Gpio2, Lpgcr, rst, gpio2);  // Note: Peripheral resets may not affect the GPIO peripherals
+generate_reset!(Dvs, Gcr, rst1, dvs); // Note: Dynamic Voltage Scaling Controller does not have its own peripheral clock
+generate_reset!(Gpio0, Gcr, rst0, gpio0); // Note: Peripheral resets may not affect the GPIO peripherals
+generate_reset!(Gpio1, Gcr, rst0, gpio1); // Note: Peripheral resets may not affect the GPIO peripherals
+generate_reset!(Gpio2, Lpgcr, rst, gpio2); // Note: Peripheral resets may not affect the GPIO peripherals
 generate_reset!(I2c0, Gcr, rst0, i2c0);
 generate_reset!(I2c1, Gcr, rst1, i2c1);
 generate_reset!(I2c2, Gcr, rst1, i2c2);

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -272,14 +272,16 @@ impl<const P: u8, const N: u8> Pin<P, N, InputOutput> {
     #[inline(always)]
     pub fn set_power_vddio(&mut self) {
         let gpio = unsafe { &*gpiox_ptr::<P>() };
-        gpio.vssel().modify(|r, w| unsafe { w.bits(r.bits() & !(1 << N)) });
+        gpio.vssel()
+            .modify(|r, w| unsafe { w.bits(r.bits() & !(1 << N)) });
     }
 
     /// Sets the pin power supply to VDDIOH.
     #[inline(always)]
     pub fn set_power_vddioh(&mut self) {
         let gpio = unsafe { &*gpiox_ptr::<P>() };
-        gpio.vssel().modify(|r, w| unsafe { w.bits(r.bits() | (1 << N)) });
+        gpio.vssel()
+            .modify(|r, w| unsafe { w.bits(r.bits() | (1 << N)) });
     }
 }
 
@@ -419,10 +421,18 @@ macro_rules! gpio {
     };
 }
 
-gpio!(Gpio0, gpio0, gcr, 0, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30]);
+gpio!(
+    Gpio0,
+    gpio0,
+    gcr,
+    0,
+    [
+        0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24,
+        25, 26, 27, 28, 29, 30
+    ]
+);
 gpio!(Gpio1, gpio1, gcr, 1, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
 gpio!(Gpio2, gpio2, lpgcr, 2, [0, 1, 2, 3, 4, 5, 6, 7]);
-
 
 /// Zero runtime cost function to get the address of a GPIO peripheral.
 #[inline(always)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,20 +2,20 @@
 #![no_std]
 #![feature(doc_cfg)]
 
+/// Entry point for the runtime application.
+pub use cortex_m_rt::entry;
 /// Re-export of the Peripheral Access Crate (PAC) for the MAX78000.
 pub use max78000_pac as pac;
 pub use pac::Interrupt;
-/// Entry point for the runtime application.
-pub use cortex_m_rt::entry;
 
 mod private {
     pub trait Sealed {}
 }
 use private::Sealed;
 
+pub mod aes;
 pub mod flc;
 pub mod gcr;
 pub mod gpio;
 pub mod trng;
 pub mod uart;
-pub mod aes;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,3 +17,4 @@ pub mod gcr;
 pub mod gpio;
 pub mod trng;
 pub mod uart;
+pub mod aes;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,19 +2,19 @@
 #![no_std]
 #![feature(doc_cfg)]
 
+/// Entry point for the runtime application.
+pub use cortex_m_rt::entry;
 /// Re-export of the Peripheral Access Crate (PAC) for the MAX78000.
 pub use max78000_pac as pac;
 pub use pac::Interrupt;
-/// Entry point for the runtime application.
-pub use cortex_m_rt::entry;
 
 mod private {
     pub trait Sealed {}
 }
 use private::Sealed;
 
+pub mod aes;
 pub mod gcr;
 pub mod gpio;
 pub mod trng;
 pub mod uart;
-pub mod aes;

--- a/src/trng.rs
+++ b/src/trng.rs
@@ -25,7 +25,9 @@ impl Trng {
     /// Create a new TRNG peripheral instance.
     pub fn new(trng: crate::pac::Trng, reg: &mut crate::gcr::GcrRegisters) -> Self {
         use crate::gcr::ClockForPeripheral;
-        unsafe { trng.enable_clock(&mut reg.gcr); }
+        unsafe {
+            trng.enable_clock(&mut reg.gcr);
+        }
         Self { trng }
     }
 

--- a/src/uart.rs
+++ b/src/uart.rs
@@ -3,15 +3,11 @@ use core::marker::PhantomData;
 use core::ops::Deref;
 
 use crate::gcr::{
+    clocks::{Clock, InternalBaudRateOscillator, PeripheralClock},
     ClockForPeripheral,
-    clocks::{
-        Clock,
-        InternalBaudRateOscillator,
-        PeripheralClock,
-    }
 };
-use crate::gpio::{Pin, Af1};
-use embedded_hal_nb::{serial, nb};
+use crate::gpio::{Af1, Pin};
+use embedded_hal_nb::{nb, serial};
 use paste::paste;
 
 enum UartClockSource {
@@ -143,7 +139,7 @@ pub struct BuiltUartPeripheral<UART, RX, TX, CTS, RTS> {
     _rx_pin: RX,
     _tx_pin: TX,
     _cts_pin: CTS,
-    _rts_pin: RTS
+    _rts_pin: RTS,
 }
 
 // TODO
@@ -257,11 +253,14 @@ uart! {Uart2,
 /// # Clock Methods
 /// You must set the clock source for the UART peripheral after using a
 /// constructor and before building the peripheral.
-impl<UART, RX, TX, CTS, RTS> UartPeripheral<marker::NotBuilt, marker::NotClockSet, UART, RX, TX, CTS, RTS> {
+impl<UART, RX, TX, CTS, RTS>
+    UartPeripheral<marker::NotBuilt, marker::NotClockSet, UART, RX, TX, CTS, RTS>
+{
     /// Set the clock source for the UART peripheral to the PCLK.
-    pub fn clock_pclk(self, clock: &Clock<PeripheralClock>) ->
-    UartPeripheral<marker::NotBuilt, marker::ClockSet, UART, RX, TX, CTS, RTS>
-    {
+    pub fn clock_pclk(
+        self,
+        clock: &Clock<PeripheralClock>,
+    ) -> UartPeripheral<marker::NotBuilt, marker::ClockSet, UART, RX, TX, CTS, RTS> {
         UartPeripheral {
             _state: PhantomData,
             _clock: PhantomData,
@@ -280,9 +279,10 @@ impl<UART, RX, TX, CTS, RTS> UartPeripheral<marker::NotBuilt, marker::NotClockSe
     }
 
     /// Set the clock source for the UART peripheral to the IBRO.
-    pub fn clock_ibro(self, clock: &Clock<InternalBaudRateOscillator>) ->
-    UartPeripheral<marker::NotBuilt, marker::ClockSet, UART, RX, TX, CTS, RTS>
-    {
+    pub fn clock_ibro(
+        self,
+        clock: &Clock<InternalBaudRateOscillator>,
+    ) -> UartPeripheral<marker::NotBuilt, marker::ClockSet, UART, RX, TX, CTS, RTS> {
         UartPeripheral {
             _state: PhantomData,
             _clock: PhantomData,
@@ -307,10 +307,10 @@ impl<UART, RX, TX, CTS, RTS> UartPeripheral<marker::NotBuilt, marker::NotClockSe
 /// with the [`UartPeripheral::build()`] method called at the end.
 impl<CLOCK, UART, RX, TX, CTS, RTS> UartPeripheral<marker::NotBuilt, CLOCK, UART, RX, TX, CTS, RTS>
 where
-    UART: Deref<Target = UartRegisterBlock>
+    UART: Deref<Target = UartRegisterBlock>,
 {
     /// Set the baud rate (bits per second) for the UART peripheral.
-    /// 
+    ///
     /// Default: `115200`
     pub fn baud(mut self, baud: u32) -> Self {
         self.baud = baud;
@@ -318,7 +318,7 @@ where
     }
 
     /// Set the number of data bits for the UART peripheral.
-    /// 
+    ///
     /// Default: [`DataBits::Eight`]
     pub fn data_bits(mut self, data_bits: DataBits) -> Self {
         self.data_bits = data_bits;
@@ -326,7 +326,7 @@ where
     }
 
     /// Set the number of stop bits for the UART peripheral.
-    /// 
+    ///
     /// Default: [`StopBits::One`]
     pub fn stop_bits(mut self, stop_bits: StopBits) -> Self {
         self.stop_bits = stop_bits;
@@ -334,7 +334,7 @@ where
     }
 
     /// Set the parity for the UART peripheral.
-    /// 
+    ///
     /// Default: [`ParityBit::None`]
     pub fn parity(mut self, parity: ParityBit) -> Self {
         self.parity = parity;
@@ -368,8 +368,10 @@ where
     // }
 }
 
-impl<UART, RX, TX, CTS, RTS> UartPeripheral<marker::NotBuilt, marker::ClockSet, UART, RX, TX, CTS, RTS>
-where UART: Deref<Target = UartRegisterBlock>
+impl<UART, RX, TX, CTS, RTS>
+    UartPeripheral<marker::NotBuilt, marker::ClockSet, UART, RX, TX, CTS, RTS>
+where
+    UART: Deref<Target = UartRegisterBlock>,
 {
     /// Apply all settings and configure the UART peripheral.
     /// This must be called before the UART peripheral can be used.
@@ -405,7 +407,9 @@ where UART: Deref<Target = UartRegisterBlock>
         });
         // Set the baud rate
         let clkdiv = clk_src_freq / self.baud;
-        self.uart.clkdiv().write(|w| unsafe { w.clkdiv().bits(clkdiv) });
+        self.uart
+            .clkdiv()
+            .write(|w| unsafe { w.clkdiv().bits(clkdiv) });
         // Wait until baud clock is ready
         while self.uart.ctrl().read().bclkrdy().bit_is_clear() {}
         BuiltUartPeripheral {
@@ -413,7 +417,7 @@ where UART: Deref<Target = UartRegisterBlock>
             _rx_pin: self._rx_pin,
             _tx_pin: self._tx_pin,
             _cts_pin: self._cts_pin,
-            _rts_pin: self._rts_pin
+            _rts_pin: self._rts_pin,
         }
     }
 }
@@ -423,7 +427,7 @@ where UART: Deref<Target = UartRegisterBlock>
 /// been built.
 impl<UART, RX, TX, CTS, RTS> BuiltUartPeripheral<UART, RX, TX, CTS, RTS>
 where
-    UART: Deref<Target = UartRegisterBlock>
+    UART: Deref<Target = UartRegisterBlock>,
 {
     #[doc(hidden)]
     #[inline(always)]
@@ -500,14 +504,14 @@ where
 // Embedded HAL non-blocking serial traits
 impl<UART, RX, TX, CTS, RTS> serial::ErrorType for BuiltUartPeripheral<UART, RX, TX, CTS, RTS>
 where
-    UART: Deref<Target = UartRegisterBlock>
+    UART: Deref<Target = UartRegisterBlock>,
 {
     type Error = serial::ErrorKind;
 }
 
 impl<UART, RX, TX, CTS, RTS> serial::Read<u8> for BuiltUartPeripheral<UART, RX, TX, CTS, RTS>
 where
-    UART: Deref<Target = UartRegisterBlock>
+    UART: Deref<Target = UartRegisterBlock>,
 {
     fn read(&mut self) -> nb::Result<u8, Self::Error> {
         self._read_byte()
@@ -516,7 +520,7 @@ where
 
 impl<UART, RX, TX, CTS, RTS> serial::Write<u8> for BuiltUartPeripheral<UART, RX, TX, CTS, RTS>
 where
-    UART: Deref<Target = UartRegisterBlock>
+    UART: Deref<Target = UartRegisterBlock>,
 {
     fn write(&mut self, byte: u8) -> nb::Result<(), Self::Error> {
         self._write_byte(byte)
@@ -531,14 +535,14 @@ where
 // Embedded IO traits
 impl<UART, RX, TX, CTS, RTS> embedded_io::ErrorType for BuiltUartPeripheral<UART, RX, TX, CTS, RTS>
 where
-    UART: Deref<Target = UartRegisterBlock>
+    UART: Deref<Target = UartRegisterBlock>,
 {
     type Error = core::convert::Infallible;
 }
 
 impl<UART, RX, TX, CTS, RTS> embedded_io::Read for BuiltUartPeripheral<UART, RX, TX, CTS, RTS>
 where
-    UART: Deref<Target = UartRegisterBlock>
+    UART: Deref<Target = UartRegisterBlock>,
 {
     fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Error> {
         let mut count = 0;
@@ -565,7 +569,7 @@ where
 
 impl<UART, RX, TX, CTS, RTS> embedded_io::ReadReady for BuiltUartPeripheral<UART, RX, TX, CTS, RTS>
 where
-    UART: Deref<Target = UartRegisterBlock>
+    UART: Deref<Target = UartRegisterBlock>,
 {
     fn read_ready(&mut self) -> Result<bool, Self::Error> {
         Ok(!self._is_rx_empty())
@@ -574,7 +578,7 @@ where
 
 impl<UART, RX, TX, CTS, RTS> embedded_io::Write for BuiltUartPeripheral<UART, RX, TX, CTS, RTS>
 where
-    UART: Deref<Target = UartRegisterBlock>
+    UART: Deref<Target = UartRegisterBlock>,
 {
     fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
         for byte in buf {
@@ -591,7 +595,7 @@ where
 
 impl<UART, RX, TX, CTS, RTS> embedded_io::WriteReady for BuiltUartPeripheral<UART, RX, TX, CTS, RTS>
 where
-    UART: Deref<Target = UartRegisterBlock>
+    UART: Deref<Target = UartRegisterBlock>,
 {
     fn write_ready(&mut self) -> Result<bool, Self::Error> {
         Ok(!self._is_tx_full())


### PR DESCRIPTION
This pull request introduces an AES hardware abstraction layer for the MAX78000 HAL. The new module provides functionality for configuring and using the AES peripheral, including support for key management, encryption, and decryption in 16-byte blocks.

---

## Key Features
1. **AES Key Management**:
   - Supports 128-bit, 192-bit, and 256-bit keys using the `Key` enum.
   - Hardware initialization and key flushing handled automatically.

2. **Encryption and Decryption**:
   - Configurable cipher modes for encryption and decryption.
   - Processes data in 16-byte chunks through the AES FIFO interface.

3. **FIFO Operations**:
   - Reads and writes to the AES hardware FIFOs for efficient block-based data processing.

---

## Added Files
- `aes.rs`: Contains the AES hardware abstraction implementation.

---

## Code Example

```rust
use crate::aes::{AES, CipherType, Key};

fn example(aes: &mut AES) {
    // Initialize a 128-bit AES key
    let key = Key::Bits128(&[0x00; 16]);
    aes.set_key(&key);

    // Prepare data to encrypt
    let plaintext = [0x01; 32]; // 32 bytes of plaintext
    let mut ciphertext = [0u8; 32];

    // Encrypt the data
    aes.set_cipher_type(CipherType::Encrypt);
    aes.write_data_to_fifo(&plaintext);
    aes.read_data_from_fifo(&mut ciphertext);

    // Decrypt the data
    aes.set_cipher_type(CipherType::Decrypt);
    aes.write_data_to_fifo(&ciphertext);
    aes.read_data_from_fifo(&mut ciphertext);
}

```