### PR TITLE
fix: remove nightly feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -101,7 +101,7 @@ dependencies = [
 
 [[package]]
 name = "max7800x-hal"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "cortex-m",
  "cortex-m-rt",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "max7800x-hal"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["SIGPwny <hello@sigpwny.com>", "Minh Duong <hello@whitehoodhacker.net>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,5 @@
 //! # Hardware Abstraction Layer for MAX7800x Microcontrollers
 #![no_std]
-#![feature(doc_cfg)]
 
 /// Re-export of the Peripheral Access Crate (PAC) for the MAX78000.
 pub use max78000_pac as pac;

--- a/src/trng.rs
+++ b/src/trng.rs
@@ -60,7 +60,6 @@ impl Trng {
 /// let mut buffer = [0u8; 16];
 /// trng.fill_bytes(&mut buffer);
 /// ```
-#[doc(cfg(feature = "rand"))]
 #[cfg(feature = "rand")]
 impl RngCore for Trng {
     #[inline(always)]


### PR DESCRIPTION
The nightly feature was only being used for docs, but it prevented compilation on non-nightly Rust installations.