### PR TITLE
chore: bump rand_core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -110,7 +110,6 @@ dependencies = [
  "embedded-io",
  "max78000-pac",
  "paste",
- "rand",
  "rand_core",
 ]
 
@@ -154,19 +153,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
-dependencies = [
- "rand_core",
-]
-
-[[package]]
 name = "rand_core"
-version = "0.6.4"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+checksum = "b08f3c9802962f7e1b25113931d94f43ed9725bebc59db9d0c3e9a23b67e15ff"
+dependencies = [
+ "zerocopy",
+]
 
 [[package]]
 name = "rustc_version"
@@ -228,4 +221,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de437e2a6208b014ab52972a27e59b33fa2920d3e00fe05026167a1c509d19cc"
 dependencies = [
  "vcell",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b8c07a70861ce02bad1607b5753ecb2501f67847b9f9ada7c160fff0ec6300c"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5226bc9a9a9836e7428936cde76bb6b22feea1a8bfdbc0d241136e4d13417e25"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,12 +21,11 @@ embedded-hal-nb = "1.0.0"
 embedded-io = "0.6.1"
 max78000-pac = "0.3.0"
 paste = "1.0.15"
-rand = { version = "0.8.5", default-features = false, optional = true }
-rand_core = { version = "0.6.4", default-features = false, optional = true }
+rand_core = { version = "0.9.0", default-features = false, optional = true }
 
 [features]
 default = ["rand", "rt"]
 # Enabling this adds the `.flashprog` section header to critical flash programming functions for custom linkage
 flashprog-linkage = []
-rand = ["dep:rand", "dep:rand_core"]
+rand = ["dep:rand_core"]
 rt = ["max78000-pac/critical-section", "max78000-pac/rt"]

--- a/src/trng.rs
+++ b/src/trng.rs
@@ -2,6 +2,7 @@
 //!
 //! The TRNG is a hardware module that generates random numbers using
 //! physical entropy sources.
+#[cfg(feature = "rand")]
 use rand_core::CryptoRng;
 #[cfg(feature = "rand")]
 use rand_core::RngCore;

--- a/src/trng.rs
+++ b/src/trng.rs
@@ -2,9 +2,9 @@
 //!
 //! The TRNG is a hardware module that generates random numbers using
 //! physical entropy sources.
-use rand::Error;
+use rand_core::CryptoRng;
 #[cfg(feature = "rand")]
-use rand::RngCore;
+use rand_core::RngCore;
 #[cfg(feature = "rand")]
 use rand_core::impls::{fill_bytes_via_next, next_u64_via_u32};
 
@@ -76,10 +76,7 @@ impl RngCore for Trng {
     fn fill_bytes(&mut self, dest: &mut [u8]) {
         fill_bytes_via_next(self, dest);
     }
-
-    #[inline(always)]
-    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), Error> {
-        self.fill_bytes(dest);
-        Ok(())
-    }
 }
+
+#[cfg(feature = "rand")]
+impl CryptoRng for Trng {}


### PR DESCRIPTION
Bumps rand_core to version `0.9.0` and implements `CryptoRng` for the peripheral.